### PR TITLE
Changed names - removed parallel task comment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,11 +23,11 @@
 
 	<target name="run_parallel_tasks">
 		<parallel threadCount="${threads}">
-			<phingcall target="tasks_to_try_parallel" />	
+			<phingcall target="tasks_to_try" />	
 		</parallel>		
 	</target>
 	<target name="run_serial_tasks">
-		<phingcall target="tasks_to_try_parallel" />
+		<phingcall target="tasks_to_try" />
 	</target>
 	<target name="tasks_to_try">
 		<phingcall target="pdepend" />


### PR DESCRIPTION
In order for phing to run parallel tasks, PHP must have pcntl support
@see http://www.phing.info/docs/guide/stable/chapters/appendixes/AppendixC-OptionalTasks.html#ParallelTask
